### PR TITLE
Amendments for lamobo-r1 platform.

### DIFF
--- a/recipes-kernel/linux/files/overlayfs.cfg
+++ b/recipes-kernel/linux/files/overlayfs.cfg
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: MIT
+CONFIG_OVERLAY_FS=y

--- a/recipes-kernel/linux/linux-%.bbappend
+++ b/recipes-kernel/linux/linux-%.bbappend
@@ -1,4 +1,3 @@
-require linux-readonly-rootfs-overlay.inc
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 SRC_URI:append = " \
   file://overlayfs.cfg \

--- a/recipes-kernel/linux/linux-%.bbappend
+++ b/recipes-kernel/linux/linux-%.bbappend
@@ -1,1 +1,5 @@
 require linux-readonly-rootfs-overlay.inc
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+SRC_URI:append = " \
+  file://overlayfs.cfg \
+"


### PR DESCRIPTION
The amendments was caused by repo `meta-sunxi` that seems not to use `yocto-cache-repository`.